### PR TITLE
added graphics directory with two papers

### DIFF
--- a/computer_graphics/README.md
+++ b/computer_graphics/README.md
@@ -1,0 +1,2 @@
+* [the-rendering-equation](http://x86.cs.duke.edu/courses/cps124/fall09/notes/16_rendering/p143-kajiya.pdf)
+* [an-improved-illumination-model-for-shaded-display](https://www.cs.drexel.edu/~david/Classes/CS586/Papers/p343-whitted.pdf)


### PR DESCRIPTION
I noticed there were no papers from the field of computer graphics.  Here are two historically significant papers from this field.  The techniques described in these papers underlie much of today's graphics technology.  I'm not sure what the copyright restrictions are on these papers, but I have linked to the URLs at which I found them.
1. [The Rendering Equation by James T. Kajiya.](http://x86.cs.duke.edu/courses/cps124/fall09/notes/16_rendering/p143-kajiya.pdf)
2. [An Improved Illumination Model for Shaded Display by Turner Whitted](https://www.cs.drexel.edu/~david/Classes/CS586/Papers/p343-whitted.pdf)
