### PR TITLE
Turing1936

### DIFF
--- a/comp_sci_fundamentals_and_history/README.md
+++ b/comp_sci_fundamentals_and_history/README.md
@@ -1,1 +1,2 @@
 * [Turing, On computable numbers, with an application to the Entscheidungsproblem](http://www.turingarchive.org/browse.php/B/12)
+* [Mealy, A Method for Synthesizing Sequential Circuits] (http://www3.alcatel-lucent.com/bstj/vol34-1955/bstj-vol34-issue05.html)


### PR DESCRIPTION
This commit adds a link to Turing's 1936 paper outlining Turing Machines, as well as a link to Mealy's 1955 paper outlining Mealy Machines.
