### PR TITLE
Add links to Calvin papers

### DIFF
--- a/distributed_systems/README.md
+++ b/distributed_systems/README.md
@@ -6,6 +6,18 @@
 
 * [Above the Clouds: A Berkeley View of Cloud Computing](http://www.eecs.berkeley.edu/Pubs/TechRpts/2009/EECS-2009-28.pdf)
 
+* The Calvin papers:
+
+  * [The Case for Determinism in Database Systems](http://cs-www.cs.yale.edu/homes/dna/papers/determinism-vldb10.pdf)
+
+  * [Consistency Tradeoffs in Modern Distributed Database System Design](http://cs-www.cs.yale.edu/homes/dna/papers/abadi-pacelc.pdf)
+
+  * [Modularity and Scalability in Calvin](http://sites.computer.org/debull/A13june/calvin1.pdf)
+
+  * [Calvin: Fast Distributed Transactions for Partitioned Database Systems](http://www.cs.yale.edu/homes/dna/papers/calvin-sigmod12.pdf)
+
+  * [Lightweight Locking for Main Memory Database Systems](http://cs-www.cs.yale.edu/homes/dna/papers/vll-vldb13.pdf)
+
 * [Cassandra - A Decentralized Structured Storage System](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.161.6751&rep=rep1&type=pdf)
 
 * [Chord: A Scalable Peer-to-peer Lookup Service for Internet Applications](http://pdos.csail.mit.edu/papers/chord:sigcomm01/chord_sigcomm.pdf)


### PR DESCRIPTION
The Calvin papers are the source material for my talk, [PWL2#4](http://www.meetup.com/papers-we-love-too/events/171291972).

These papers are not licensed for inclusion in the git repo, so I added links to the README.

The five links are grouped under a single top-level bullet, because otherwise it would be hard to correlate them.
