### PR TITLE
added space after a md formatted link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Let us know if you are interested in starting a [chapter](https://github.com/pap
 View a complete list of [past presentations](https://github.com/papers-we-love/papers-we-love/wiki/Past-Presentations) or check out our [Youtube](http://www.youtube.com/user/PapersWeLove) and [MixCloud](http://www.mixcloud.com/paperswelove/) (audio-only format) channels.
 
 ## Search this Repo!
-[@polyfractal](https://github.com/polyfractal) indexed this repository with Elastic Search. Find papers [here](http://findpaperswelove.com)!
+[@polyfractal](https://github.com/polyfractal) indexed this repository with Elastic Search. Find papers [here](http://findpaperswelove.com) !
 
 ## Info
 

--- a/android/README.md
+++ b/android/README.md
@@ -2,7 +2,7 @@
 
 ## Security
 
-* Referenced by [Two Secure Coding Tools for Analyzing Android Apps](http://blog.sei.cmu.edu/post.cfm/secure-coding-tools-analyzing-android-apps-118):
+* Referenced by [Two Secure Coding Tools for Analyzing Android Apps](http://blog.sei.cmu.edu/post.cfm/secure-coding-tools-analyzing-android-apps-118) :
     * [Analyzing Inter-Application Communication in Android](https://www.eecs.berkeley.edu/~daw/papers/intents-mobisys11.pdf)
     * [Effective Inter-Component Communication Mapping in Android with Epicc: An Essential Step Towards Holistic Security Analysis](http://www.cse.psu.edu/~duo114/pubs/octeau-sec13.pdf)
     * [FlowDroid: Precise Context, Flow, Field, Object-sensitive and Lifecycle-aware Taint Analysis for Android Apps](http://www.bodden.de/pubs/far+14flowdroid.pdf)


### PR DESCRIPTION
```
bad: [my link](http://my.link.com): blahblah
good: [my link](http://my.link.com) : blahblah

bad: [my link](http://my.link.com)! blahblah
good: [my link](http://my.link.com) ! blahblah
```

without the space, url_checker_pwl.pl will get confused
