### PR TITLE
adds Sammet PL history paper

### DIFF
--- a/plt/README.md
+++ b/plt/README.md
@@ -3,3 +3,5 @@
 * [Can Programming Be Liberated from the von Neumann Style? A Functional Style and Its Algebra of Programs](http://www.thocp.net/biographies/papers/backus_turingaward_lecture.pdf)
 
 * [Programming and Reasoning with Algebraic Effects and Dependent Types](http://eb.host.cs.st-andrews.ac.uk/drafts/effects.pdf)
+
+* [Programming Languages: History and Future](http://www.csee.umbc.edu/courses/undergraduate/CMSC331/resources/papers/sammet1972.pdf)


### PR DESCRIPTION
Adds Jean Sammet paper on the History of Programming Languages. 

This paper is from 1972, mentioned by Alan Kay [here](https://queue.acm.org/detail.cfm?id=1039523) 

> In the late 1960s, Jean Sammet was able to track down and chronicle about 3,000 programming languages that were extant then.
