### PR TITLE
Update link to a portal with a download and other mirrors

### DIFF
--- a/logic_and_programming/README.md
+++ b/logic_and_programming/README.md
@@ -1,2 +1,2 @@
-* [Purely Functional Lazy Non-deterministic Programming](http://www.cs.rutgers.edu/~ccshan/rational/lazy-nondet.pdf)
+* [Purely Functional Lazy Non-deterministic Programming](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.148.524)
 * :scroll: [On the Meanings of the Logical Constants and the Justifications of the Logical Laws](http://www.pps.univ-paris-diderot.fr/~saurin/Enseignement/LMFI/articles/Martin-Lof83.pdf)


### PR DESCRIPTION
The link to a paper in logic_and_programming 404s, this links to http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.148.524, which has a link to the pdf and mirrors, but the PDF link appears to add a sessionid, hence not linking directly.
