### PR TITLE
Updates to Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -52,5 +52,5 @@ As noted above, local chapters are encouraged to fork and modify the Code of Con
 - [Geek Feminism](http://geekfeminism.org/about/code-of-conduct/)
 - [JS Conf EU](http://2014.jsconf.eu/code-of-conduct.html)
 - [Pycon](https://github.com/python/pycon-code-of-conduct/blob/master/code_of_conduct.md)
-- [Hacker School's Social Rueles](https://www.hackerschool.com/manual#sub-sec-social-rules)
+- [Hacker School's Social Rules](https://www.hackerschool.com/manual#sub-sec-social-rules)
 


### PR DESCRIPTION
The existing Code of Conduct is modeled after CoC's used at conferences within the US. PWL is a loose confederation of meet-ups with an international reach and has slightly different needs. The updated CoC still explicitly states that PWL meetups and online communities should be harassment-free environments, but that it is up to the local organizers of live events to maintain that environment.
