### PR TITLE
1) Adding paper "A Poor Man s Concurrency Monad" by Koen Claessen to the "haskell" section; 2) Adding README file for "pattern_matching" section.

### DIFF
--- a/haskell/README.md
+++ b/haskell/README.md
@@ -1,5 +1,5 @@
 # Haskell
 
-
-* [Tackling the Awkward Squad: monadic input/output, concurrency, exceptions, and foreign-language calls in Haskell](../haskell/tackling-the-awkward-squad-monadic-input-output-concurrency-exceptions-and-foreign-language-calls-in-haskell.pdf) by Simon Peyton Jones
-* [Making a Fast Curry: Push/Enter vs. Eval/Apply for Higher-order Languages](../haskell/making-a-fast-curry-push-enter-versus-eval-apply-for-higher-order-languages.pdf) by Simon Marlow and Simon Peyton Jones. A classic... describes well the execution model GHC uses for Haskell, and catches the brilliant authors in a design pivot from original intuition to new conclusions based on empirical data.
+* :scroll: [Tackling the Awkward Squad: monadic input/output, concurrency, exceptions, and foreign-language calls in Haskell](../haskell/tackling-the-awkward-squad-monadic-input-output-concurrency-exceptions-and-foreign-language-calls-in-haskell.pdf) by Simon Peyton Jones
+* :scroll: [Making a Fast Curry: Push/Enter vs. Eval/Apply for Higher-order Languages](../haskell/making-a-fast-curry-push-enter-versus-eval-apply-for-higher-order-languages.pdf) by Simon Marlow and Simon Peyton Jones. A classic... describes well the execution model GHC uses for Haskell, and catches the brilliant authors in a design pivot from original intuition to new conclusions based on empirical data.
+* :scroll: [A Poor Man's Concurrency Monad](../haskell/a-poor-mans-concurrency-monad.pdf) by Koen Claessen. Paper describes how without adding any primitives to the language, you could define a concurrency monad transformer in Haskell.

--- a/pattern_matching/README.md
+++ b/pattern_matching/README.md
@@ -1,0 +1,5 @@
+# Pattern Matching
+
+* :scroll: [Compiling Pattern Matching to good Decision Trees](../pattern_matching/compiling-pattern-matching-to-good-decision-trees.pdf) by Luc Maranget. Paper address the issue of compiling ML pattern matching to efficient decisions trees.
+* :scroll: [Extensible Pattern Matching in an Extensible Language](../pattern_matching/extensible-pattern-matching-extensible-language.pdf) by Sam Tobin-Hochstadt. Paper present a sophisticated pattern matcher for [Racket](http://racket-lang.org/), implemented as language extension using macros.
+* :scroll: [Warnings for pattern matching](../pattern_matching/warnings-for-pattern-matching.pdf) by Luc Maranget. Paper examine the ML pattern-matching anomalies of useless clauses and non-exhaustive matches.


### PR DESCRIPTION
#### (88f5b44) Adding paper "A Poor Man s Concurrency Monad" by Koen Claessen to the "haskell" section 

This paper was written by Koen Claessen (Chalmers University of Technologies).

Paper describes how without adding any primitives to the language, you could define a concurrency monad transformer in Haskell.

It was introduced to me by Erik Meijer as a part of course "DelftX: FP101x Introduction to Functional Programming" offered by DelftX, an online learning initiative of Delft University of Technology through edX.

#### (af6b4fd) Adding README file for "pattern_matching" section

I discovered that "pattern_matching" section is missing README file with short annotation of papers. With this commit I added README file with short annotation for each paper in section. 