### PR TITLE
Update README to reference the actual PWL site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## ![Papers We Love](http://papers-we-love.github.io/images/logo-top.svg)
 
-**Papers We Love** is a community built around reading, discussing and learning more about academic computer science papers. This repository serves as a directory of some of the best papers the community can find, bringing together documents scattered across the web.
+**Papers We Love** is a community built around reading, discussing and learning more about academic computer science papers. This repository serves as a directory of some of the best papers the community can find, bringing together documents scattered across the web. You can also visit the [Papers We Love site](http://paperswelove.org/) for more info.
 
 Due to [licenses](https://github.com/papers-we-love/papers-we-love#respect-content-licenses) we cannot always host the papers themselves (when we do, you will see a :scroll: emoji next to its title in the directory README) but we can provide links to their locations.
 
@@ -34,7 +34,6 @@ Here are our official chapters. Let us know if you are interested in [starting o
 * [Hyderabad](http://www.meetup.com/papers-we-love-hyderabad/)
 * [Madrid](http://www.meetup.com/Papers-We-Love-Madrid/)
 * [Amsterdam](http://www.meetup.com/papers-we-love-amsterdam/)
-* [Winnipeg](http://www.meetup.com/Papers-We-Love-Winnipeg/)
 
 All of our meetups follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 


### PR DESCRIPTION
This PR amends the opening paragraph to improve the discoverability of the PWL site from the README (which I personally didn't know existed until entering the #paperswelove channel and speaking with some folks).