### PR TITLE
Add Crash-Only Software papers

### DIFF
--- a/crash_only/README.md
+++ b/crash_only/README.md
@@ -1,0 +1,4 @@
+# Crash-Only Software
+
+* [Crash-Only Software](https://www.usenix.org/legacy/events/hotos03/tech/full_papers/candea/candea.pdf) by Candea and Fox.
+* [Microreboot -- A technique for cheap recovery](https://www.usenix.org/legacy/event/osdi04/tech/full_papers/candea/candea.pdf) by Candea, Kawamoto, Fujiki, Friedman, Fox. Follows up on the original crash-only paper to outline a broader strategy of failure management.


### PR DESCRIPTION
This adds a couple papers, primarily by [George Candea](http://people.epfl.ch/george.candea). I'll be presenting the first one, Crash-Only Software at the [http://www.meetup.com/papers-we-love-Detroit/events/221358596/](inaugural PWL Detroit meeting). Hopefully I'll find a venue and a camera, and then that'll happen soon :)

a few things:

* I've no idea about usenix and licensing, so i'm not sure if it's OK to keep them here. FWIW the front page does say, "Permission is granted for noncommercial reproduction of the work for educational or research purposes."
* I've included the microreboot paper as well because it's really a logical continuation of the same idea, though I'm not really planning to touch on it in my presentation. It's also the more heavily cited paper. I'm fine to pull it out, though, if that's the preference...
* Maybe there's a better directory to put these under already, and I'm totally fine if so...but I couldn't really pick one out.
