### PR TITLE
fix link for "Time, Clocks, and the Ordering of Events in a Distributed System"

### DIFF
--- a/concurrency/README.md
+++ b/concurrency/README.md
@@ -1,6 +1,6 @@
 * [Everything You Always Wanted to Know About Synchronization but Were Afraid to Ask](http://sigops.org/sosp/sosp13/papers/p33-david.pdf)
 
-* [Time, Clocks, and the Ordering of Events in a Distributed System](http://www.stanford.edu/class/cs240/readings/lamport.pdf)
+* [Time, Clocks, and the Ordering of Events in a Distributed System](http://research.microsoft.com/en-us/um/people/lamport/pubs/time-clocks.pdf)
 
 * [Heap Architectures For Concurrent Languages Using Message Passing](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.108.1302&rep=rep1&type=pdf)
 


### PR DESCRIPTION
original link returns a 404 now.