### PR TITLE
Fix link in information_theory/README.md

### DIFF
--- a/information_theory/README.md
+++ b/information_theory/README.md
@@ -1,4 +1,4 @@
-* :scroll: [A Mathematical Theory of Communication](http://cm.bell-labs.com/cm/ms/what/shannonday/shannon1948.pdf)
+* :scroll: [A Mathematical Theory of Communication](./a-mathematical-theory-of-communication-1948.pdf)
 
 * [Differential Privacy](http://www.msr-waypoint.com/pubs/64346/dwork.pdf)
   - How do we quantify the exposure an individual faces from being


### PR DESCRIPTION
Previously pointed to dead link instead of the repo's PDF copy.