### PR TITLE
add cuckoo hashing

### DIFF
--- a/data_structures/README.md
+++ b/data_structures/README.md
@@ -1,3 +1,4 @@
 * [Dynamic Hash Tables](http://www.csd.uoc.gr/~hy460/pdf/Dynamic%20Hash%20Tables.pdf)
 * [Simple, Fast, and Practical Non-Blocking and Blocking Concurrent Queue Algorithms](http://www.research.ibm.com/people/m/michael/podc-1996.pdf)
 * [RRB-Trees: Efﬁcient Immutable Vectors](http://infoscience.epfl.ch/record/169879/files/RMTrees.pdf)
+* [Cuckoo Hashing](http://www.it-c.dk/people/pagh/papers/cuckoo-jour.pdf)


### PR DESCRIPTION
"Cuckoo hashing is a scheme in computer programming for resolving hash collisions of values of hash functions in a table, with worst-case constant lookup time." - https://en.wikipedia.org/wiki/Cuckoo_hashing

this is related to #318