### PR TITLE
Hopscotch hashing

### DIFF
--- a/data_structures/README.md
+++ b/data_structures/README.md
@@ -2,3 +2,4 @@
 * [Simple, Fast, and Practical Non-Blocking and Blocking Concurrent Queue Algorithms](http://www.research.ibm.com/people/m/michael/podc-1996.pdf)
 * [RRB-Trees: Efﬁcient Immutable Vectors](http://infoscience.epfl.ch/record/169879/files/RMTrees.pdf)
 * [Cuckoo Hashing](http://www.it-c.dk/people/pagh/papers/cuckoo-jour.pdf)
+* [Hopscotch Hashing](http://mcg.cs.tau.ac.il/papers/disc2008-hopscotch.pdf)


### PR DESCRIPTION
Introduced by Maurice Herlihy, Nir Shavit and Moran Tzafrir in 2008,
hopscotch is a way of resolving hash collisions using open addressing
and is also useful in implementing a concurrent hash table.