### PR TITLE
Paper on RSA key extraction and publication dates

### DIFF
--- a/cryptography/README.md
+++ b/cryptography/README.md
@@ -1,9 +1,10 @@
 # Cryptography 
 
-* [A Method for Obtaining Digital Signatures and Public-Key Cryptosystems](http://people.csail.mit.edu/rivest/Rsapaper.pdf)
-* [Twenty Years of Attacks on the RSA Cryptosystem](https://crypto.stanford.edu/~dabo/papers/RSA-survey.pdf)
-* :scroll: [Communication Theory of Secrecy Systems](communication-theory-of-secrecy-systems.pdf)
-* [New Directions in Cryptography](http://www-ee.stanford.edu/~hellman/publications/24.pdf)
+* [A Method for Obtaining Digital Signatures and Public-Key Cryptosystems (1977)](http://people.csail.mit.edu/rivest/Rsapaper.pdf)
+* [Twenty Years of Attacks on the RSA Cryptosystem (1999)](https://crypto.stanford.edu/~dabo/papers/RSA-survey.pdf)
+* :scroll: [Communication Theory of Secrecy Systems (1949)](communication-theory-of-secrecy-systems.pdf)
+* [New Directions in Cryptography (1976)](http://www-ee.stanford.edu/~hellman/publications/24.pdf)
+* [RSA Key Extraction via Low-Bandwidth Acoustic Cryptanalysis (2013)](http://www.cs.tau.ac.il/~tromer/papers/acoustic-20131218.pdf)
 
 ## Related Works
 ### [A Mathematical Theory of Cryptography (1945)](http://www.cs.bell-labs.com/who/dmr/pdfs/shannoncryptshrt.pdf) - Shannon


### PR DESCRIPTION
I added the RSA Key Extraction via Low-Bandwidth Acoustic Cryptanalysis (2013) paper by Genkin, Shamir and Tromer and completed the publication dates for the existing crypto papers.