### PR TITLE
spelling error in logic_and_programming readme

### DIFF
--- a/logic_and_programming/README.md
+++ b/logic_and_programming/README.md
@@ -1,6 +1,6 @@
 ## Logic and Programming
 
-* :scroll: [Representing Game Dialogue as Expresions in Firt-Order Logic](representing-game-dialogue-as-expressions-in-first-order-logic.pdf)
+* :scroll: [Representing Game Dialogue as Expresions in First-Order Logic](representing-game-dialogue-as-expressions-in-first-order-logic.pdf)
 * :scroll: [The Event Calculus as a Linear Logic Program](event-calculus.txt)
 * [Purely Functional Lazy Non-deterministic Programming](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.148.524)
 * [:scroll:](on-the-meanings-of-the-logical-constants.pdf) [On the Meanings of the Logical Constants and the Justifications of the Logical Laws](http://www.pps.univ-paris-diderot.fr/~saurin/Enseignement/LMFI/articles/Martin-Lof83.pdf)


### PR DESCRIPTION
Simple misspelling of `first` (was `firt`).