### PR TITLE
added paper on SPDY evaluation

### DIFF
--- a/networks/README.md
+++ b/networks/README.md
@@ -2,3 +2,4 @@
 
 * [Bimodal Multicast](http://www.csl.mtu.edu/cs6461/www/Reading/Birman99.pdf)
 * [End-to-End Arguments in System Design](http://www.reed.com/dpr/locus/Papers/EndtoEnd.html)
+* [Can SPDY Really Make the Web Faster?](http://www.comp.lancs.ac.uk/~elkhatib//Docs/2014.06_Netw.pdf)


### PR DESCRIPTION
## Paper Title: Can SPDY really make the web faster?

### Paper Year: 2014

### Reasons for including paper

- A thorough evaluation of the SPDY protocol under different network and web infrastructure conditions.
- SPDY was the basis for HTTP/2.0 which is the pervasive web protocol used by all modern browsers and devices.

