### PR TITLE
Fix broken links

### DIFF
--- a/gossip/README.md
+++ b/gossip/README.md
@@ -6,13 +6,13 @@ If you only read one of these papers, start with the classic Demers, et al paper
 # Peer sampling services
 Briefly, a peer sampling service is a system that maintains a restricted set (partial view) of the all machines participating in a gossip system.
 * [The Peer Sampling Service: Experimental Evaluation of Unstructured Gossip-Based Implementations](http://infoscience.epfl.ch/record/83409/files/neg--1184036295all.pdf)
-* [HyParView](http://gsd.di.uminho.pt/jop/pdfs/LPR07b.pdf)
+* [HyParView: a membership protocol for reliable gossip-based broadcast](http://asc.di.fct.unl.pt/~jleitao/pdf/dsn07-leitao.pdf)
 * [SWIM: Scalable Weakly-consistent Infection-style Process Group Membership Protocol](http://www.cs.cornell.edu/~asdas/research/dsn02-swim.pdf)
 
 # Epidemic broadcast 
 * [Large-Scale Newscast Computing on the Internet ](http://www.soc.napier.ac.uk/~benp/dream/dreampaper17.pdf)
 * [Bimodal Multicast](http://www.csl.mtu.edu/cs6461/www/Reading/Birman99.pdf)
-* [Efficient Reconciliation and Flow Control for Anti-Entropy Protocols](http://idning-paper.googlecode.com/svn/trunk/reference/ignore/Scuttlebutt_Efficient_reconciliation_and_flow_control_for_anti-entropy_protocols.pdf)
+* [Efficient Reconciliation and Flow Control for Anti-Entropy Protocols](http://www.cs.cornell.edu/home/rvr/papers/flowgossip.pdf)
 * [Epidemic Broadcast Trees](http://www.gsd.inesc-id.pt/~ler/reports/srds07.pdf)
 
 # Failure Detectors


### PR DESCRIPTION
Fixed broken links for these two papers in the [gossip section](https://github.com/papers-we-love/papers-we-love/tree/master/gossip):
- [HyParView: a membership protocol for reliable gossip-based broadcast](http://asc.di.fct.unl.pt/~jleitao/pdf/dsn07-leitao.pdf)
- [Efficient Reconciliation and Flow Control for Anti-Entropy Protocols](http://www.cs.cornell.edu/home/rvr/papers/flowgossip.pdf)