### PR TITLE
replace broken link to dropbox paper to official usenix link

### DIFF
--- a/security/README.md
+++ b/security/README.md
@@ -2,7 +2,7 @@
 
 * [Reflections on Trusting Trust (1984)](http://www.ece.cmu.edu/~ganger/712.fall02/papers/p761-thompson.pdf)
 * [Internet Census via Insecure Routers (2012)](http://internetcensus2012.bitbucket.org/paper.html)
-* [Looking inside the (Drop) Box (2013)](http://ams2.mirrors.digitalocean.com/openwall/presentations/Security-Analysis-of-Dropbox/woot13-kholia.pdf)
+* [Looking inside the (Drop) Box (2013)](https://www.usenix.org/system/files/conference/woot13/woot13-kholia.pdf)
 * [Making Programs Forget: Enforcing Lifetime For Sensitive Data (2011)](https://www.usenix.org/events/hotos11/tech/final_files/Kannan.pdf)
 * [Breach: Reviving The Crime Attack (2013)](http://breachattack.com/resources/BREACH%20-%20SSL,%20gone%20in%2030%20seconds.pdf)
 * [Why Silent Updates Boost Security (2009)](http://www.techzoom.net/Papers/Browser_Silent_Updates_%282009%29.pdf)


### PR DESCRIPTION
## Paper Title:
Looking inside the (Drop) Box 
### Paper Year:
2013
### Reasons for including paper
The original link has be broken. Replace it with the link to Usenix site that allow free public access.
- 
-
-

