### PR TITLE
fix broken link, and remove ^M Dos/Windows carriage returns

### DIFF
--- a/functional_programming/README.md
+++ b/functional_programming/README.md
@@ -7,9 +7,10 @@
 
     > In 1991, Erik Meijer, Maarten Fokkinga, and Ross Paterson published their now-classic paper Functional Programming with Bananas, Lenses, Envelopes and Barbed Wire. Though this paper isn’t widely known outside of the functional programming community, its contributions are astonishing: the authors use category theory to express a set of simple, composable combinators, called recursion schemes, that automate the process of traversing and recursing through nested data structures. Though recursion schemes predate Meijer et. al’s work, this paper brings the enormous abstractive power of category theory to bear on the subject of traversing data structures—it’s a magnificent example of how category-theoretical concepts can bring both rigor and simplicity to day-to-day programming tasks.
     
-* :scroll: [Equal Rights for Functional Objects or,The More Things Change, The More They Are the Same](equal-rights-for-functional-objects.pdf)
-* :scroll: [Optimal Purely Functional Priority Queues](optimal-purely-functional-priority-queues.pdf)
-* :scroll: [Why Functional Programming Matters](why-functional-programming-matters.pdf)
+* :scroll: [Equal Rights for Functional Objects or,
+The More Things Change, The More They Are the Same](equal-rights-for-functional-objects.pdf)
+* :scroll: [Optimal Purely Functional Priority Queues](optimal-purely-functional-priority-queues.pdf)
+* :scroll: [Why Functional Programming Matters](why-functional-programming-matters.pdf)
 
 
 ## Applicative Programming
@@ -20,7 +21,7 @@
 
 ## Concatenative Programming
 
-* [:scroll:](concatenative-programming-an-overlooked-paradigm.pdf) [Concatenative Programming: An Overlooked Paradigm in Functional Programming](https://github.com/dterei/Research-Papers/blob/master/To%20Read/CONCATENATIVE%20PROGRAMMING%0AAn%20Overlooked%20Paradigm%20in%20Functional%20Programming.pdf)
+* :scroll: [Concatenative Programming: An Overlooked Paradigm in Functional Programming](concatenative-programming-an-overlooked-paradigm.pdf)
 
 ## Imperative Programming - Functional Programming
 


### PR DESCRIPTION
closes #386

- fixes broken link
- removes ^M dos/windows carriage returns 

-----
Also: note that the location of the source paper has moved.
The new URL of the (non-hosted) original source of this article is now at: 

https://github.com/dterei/Research-Papers/blob/master/Read/FP/CONCATENATIVE%20PROGRAMMING%0AAn%20Overlooked%20Paradigm%20in%20Functional%20Programming.pdf

-------
(Previously it was located at:
https://github.com/dterei/Research-Papers/blob/master/To%20Read/CONCATENATIVE%20PROGRAMMING%0AAn%20Overlooked%20Paradigm%20in%20Functional%20Programming.pdf
)