### PR TITLE
Add the Sketch-n-Sketch paper

### DIFF
--- a/languages/domain-specific-languages/README.md
+++ b/languages/domain-specific-languages/README.md
@@ -1,0 +1,6 @@
+[Programmatic and Direct Manipulation, Together at Last](http://arxiv.org/abs/1507.02988). Ravi
+Chugh, Brian Hempel, Mitchell Spradlin, and Jacob Albers. PLDI 2016.
+> Introduces the idea of "prodirect manipulation" for creating visual artifacts,
+> a hybrid of the direct manipulation technique used in WYSIWYG programs like
+> Photoshop and PowerPoint, and the programmatic manipulation used in languages
+> and libraries such as LaTeX and Processing.


### PR DESCRIPTION
## Paper Title
Programmatic and Direct Manipulation, Together at Last

### Paper Year
2016

### Reasons for including paper
 Introduces the idea of "prodirect manipulation" for creating visual artifacts, a hybrid of the direct manipulation technique used in WYSIWYG programs like Photoshop and PowerPoint, and the programmatic manipulation used in languages and libraries such as LaTeX and Processing.

