### PR TITLE
Fixing readme entry in memory management

### DIFF
--- a/memory_management/README.md
+++ b/memory_management/README.md
@@ -2,7 +2,7 @@
 
 * [A Unified Theory of Garbage Collection](http://www.cs.virginia.edu/~cs415/reading/bacon-garbage.pdf)
 
-* [Teaching Garbage Collection without Implementing Compilers or Interpreters](http://faculty.cs.byu.edu/~jay/static/cooper-sigcse2013.pdf)
+* [Teaching Garbage Collection without Implementing Compilers or Interpreters](https://cs.brown.edu/~sk/Publications/Papers/Published/cgkmf-teach-gc/paper.pdf)
 
 * [Message Analysis Guided Allocation and Low Pause Incremental GC in a Concurrent Language](http://user.it.uu.se/~kostis/Papers/ismm04.pdf)
 


### PR DESCRIPTION
## Paper Title:Teaching Garbage Collection without Implementing Compilers or Interpreters

### Paper Year: 2013

### Reasons for including paper : The Readme Link was pointing to a broken link. I am making a change to put to a link still active with the same paper.

-
-
-
