### PR TITLE
Add Combinatorial Analysis and Computers (1965)

### DIFF
--- a/combinatory_logic/README.md
+++ b/combinatory_logic/README.md
@@ -1,3 +1,12 @@
-#Combinatory Logic
+# Combinatory Logic
 
-* [Flattening Combinators: Surviving Without Parentheses](http://www.westpoint.edu/eecs/SiteAssets/SitePages/Faculty%20Publication%20Documents/Okasaki/jfp03flat.pdf) by Chris Okasaki
+* [Flattening Combinators: Surviving Without Parentheses]
+  by Chris Okasaki (2003)
+
+* [Combinatorial Analysis and Computers]
+  by Marshall Hall Jr. and Donald E. Knuth (1965)
+
+[Flattening Combinators: Surviving Without Parentheses]:
+    http://www.westpoint.edu/eecs/SiteAssets/SitePages/Faculty%20Publication%20Documents/Okasaki/jfp03flat.pdf
+[Combinatorial Analysis and Computers]:
+    http://poncelet.math.nthu.edu.tw/disk5/js/computer/hall-knuth.pdf


### PR DESCRIPTION
## Paper Title: Combinatorial Analysis and Computers

### Paper Authors: Hall and Knuth

### Paper Year: 1965

### Reasons for including paper

  Papers We Love DC/NoVA will be discussing this paper (and others) at our
  November meetup.

  This paper is included in Donald Knuth's book *Selected Papers
  on Discrete Mathematics*. Knuth's writings have been extremely
  important to the field of computer science, and I think that most of
  his papers would fit in well here. This one introduces computational
  complexity and the benefits/limits of computing, then it dives into
  several combinatorial problems.

  I find it interesting because 1) it's a neat view of the possibilities and
  limitations of computation early on, and 2) the problems that he lays out
  are interesting exercises even today.

---

#### Changes

  - add: *Combinatorial Analysis and Computers* (1965) to
         `combinatory_logic/README.md` list
  - add: year to the other paper in the README
  - fix: tweak format of papers README for readability

#### Decisions:

  - I put this in the `combinatory_logic` folder, but I think it would
    also fit in the `comp_sci_fundamentals_and_history` folder (given
    Knuth's historical importance to the field and the more
    theoretical nature of the paper). This seemed more direct.