### PR TITLE
adds raleigh-durham chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Here are our official chapters. Let us know if you are interested in [starting o
 * [Philadelphia](http://www.meetup.com/Papers-We-Love-Philadelphia/)
 * [Portland](http://www.meetup.com/Papers-We-Love-PDX/)
 * [Pune](http://www.meetup.com/Doo-Things)
+* [Raleigh-Durham](https://www.meetup.com/Papers-We-Love-Raleigh-Durham/)
 * [Reykjavík](http://www.meetup.com/Papers-We-Love-Reykjavik)
 * [San Diego](http://www.meetup.com/Papers-We-Love-San-Diego/)
 * [San Francisco](http://www.meetup.com/papers-we-love-too/)


### PR DESCRIPTION
Papers We Love Raleigh-Durham had its first meetup on January 12th 2017.

All media from the event can be found here: 
https://www.meetup.com/Papers-We-Love-Raleigh-Durham/events/235513891/

All content discussed is in the following repository:
https://github.com/rdu-papers-we-love/raleigh-durham-chapter

The video content has been uploaded to youtube here:
https://www.youtube.com/watch?v=wavpTQmK0Fs