### PR TITLE
Fix broken link to ACM copyright link in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,7 +11,7 @@ We want to help bring academic research closer to practitioners and we strive to
 
 ### Respect content licenses
 
-* **We will only merge pull requests that contain research papers that allow digital distribution.** Papers whose copyright prohibits redistribution will not be accepted; please refer to the [ACM digital library copyright policy](http://www.acm.org/publications/policies/copyright_policy).
+* **We will only merge pull requests that contain research papers that allow digital distribution.** Papers whose copyright prohibits redistribution will not be accepted; for example [license 1](http://www.acm.org/publications/policies/copyright-policy-v1/) from the [ACM digital library](http://www.acm.org/publications/policies/copyright_policy).
 * We encourage papers that do not allow digital distribution to be added to a README, with a link to the source URL, in the appropriate subject's folder. For example, [the distributed systems README](https://github.com/papers-we-love/papers-we-love/blob/master/distributed_systems/README.md).
 
 ### Follow our commit, naming, and directory-organization conventions

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,7 +11,7 @@ We want to help bring academic research closer to practitioners and we strive to
 
 ### Respect content licenses
 
-* **We will only merge pull requests that contain research papers that allow digital distribution.** Papers whose copyright prohibits redistribution will not be accepted; for example [license 1](http://www.acm.org/publications/policies/copyright-policy-v1) from the [ACM digital library](http://www.acm.org/publications/policies/copyright_policy).
+* **We will only merge pull requests that contain research papers that allow digital distribution.** Papers whose copyright prohibits redistribution will not be accepted; please refer to the [ACM digital library copyright policy](http://www.acm.org/publications/policies/copyright_policy).
 * We encourage papers that do not allow digital distribution to be added to a README, with a link to the source URL, in the appropriate subject's folder. For example, [the distributed systems README](https://github.com/papers-we-love/papers-we-love/blob/master/distributed_systems/README.md).
 
 ### Follow our commit, naming, and directory-organization conventions


### PR DESCRIPTION
Link to ACM's copyright policy license 1 does not exist anymore. Link has been replaced with a general ACM copyright website's link.