### PR TITLE
Adding kvm paper; sub-sections in operations_systems

### DIFF
--- a/operating_systems/README.md
+++ b/operating_systems/README.md
@@ -2,14 +2,26 @@
 
 * :scroll: [The UNIX Time-Sharing System](unix-time-sharing-system.pdf)
 
-* [Xen and the Art of Virtualization](http://www.cl.cam.ac.uk/research/srg/netos/papers/2003-xensosp.pdf)
-
 * [The operating system: should there be one?](http://plosworkshop.org/2013/preprint/kell.pdf)
 
 * [The Scalable Commutativity Rule: Designing Scalable Software for Multicore Processors](https://people.csail.mit.edu/nickolai/papers/clements-sc.pdf)
 
+## System Virtualization
+
+* [Xen and the Art of Virtualization](http://www.cl.cam.ac.uk/research/srg/netos/papers/2003-xensosp.pdf)
+
+* :scroll: [kvm: the Linux Virtual Machine Monitor](kvm-linux-virtual-machines-monitor.pdf)
+
+### Live migration of Virtual Machines
+
 * :scroll: [Live Migration of Virtual Machines](live-migration-of-virtual-machines.pdf)
+
+## Jails and containers
 
 * :scroll: [Jails: Confining the omnipotent root.](https://us-east.manta.joyent.com/bcantrill/public/ppwl-cantrill-jails.pdf)
 
 * :scroll: [Solaris Zones: Operating System Support for Consolidating Commercial Workloads](https://us-east.manta.joyent.com/bcantrill/public/ppwl-cantrill-zones.pdf)
+
+
+
+


### PR DESCRIPTION
## Paper Title: kvm: the Linux Virtual Machine Monitor

### Paper Year: 2007

### Reasons for including paper

- kvm is a widely used Hypervisor, the paper details on design and implementation as well as challenges in integrating it with the Linux kernel (notably by Google)
- Xen and KVM have different designs of hypervisor software; both have their pros and cons.


I've introduced categories as operating_systems is too big a research umbrella.
We can break them off later if the need arises.
