### PR TITLE
Add Erlang papers

### DIFF
--- a/languages/erlang/README.md
+++ b/languages/erlang/README.md
@@ -1,0 +1,6 @@
+# Erlang
+
+* [Making reliable distributed systems in the presence of software errors](http://erlang.org/download/armstrong_thesis_2003.pdf)
+PhD thesis of Joe Armstrong, Erlang’s co-inventor, describing the origins of Erlang.
+
+* [A History of Erlang](http://webcem01.cem.itesm.mx:8005/erlang/cd/downloads/hopl_erlang.pdf) by Joe Armstrong


### PR DESCRIPTION
## Paper Title: Making reliable distributed systems in the presence of software errors

### Paper Year: 2003

### Reasons for including paper

- PhD thesis of Joe Armstrong, Erlang’s co-inventor, describing the origins of Erlang.

## Paper Title: A History of Erlang

### Paper Year: 2007

### Reasons for including paper

- A history of Erlang programming language
