### PR TITLE
Fix broken link in Quantum Computing

### DIFF
--- a/quantum_computing/README.md
+++ b/quantum_computing/README.md
@@ -2,7 +2,7 @@
 
 ## Included Papers
 
-* [:scroll:](advance_in_quantum_machine_learning.pdf) [Advances in quantum machine learning (2015)](https://arxiv.org/abs/1514.02900) (Jeremy Adcock, Euan Allen, Matthew Day, Stefan Frick, Janna Hinchliff, Mack Johnson, Sam Morley-Short, Sam Pallister, Alasdair Price, Stasja Stanisic)
+* [:scroll:](advance_in_quantum_machine_learning.pdf) [Advances in quantum machine learning (2015)](https://arxiv.org/abs/1512.02900) (Jeremy Adcock, Euan Allen, Matthew Day, Stefan Frick, Janna Hinchliff, Mack Johnson, Sam Morley-Short, Sam Pallister, Alasdair Price, Stasja Stanisic)
 
 * [:scroll:](shors_algorithm.pdf) [Shors algorithm for polynomial time prime factorization (1995)](https://arxiv.org/pdf/quant-ph/9508027.pdf) (Peter W Shor)
 


### PR DESCRIPTION
Fix broken link to "Advances in quantum machine learning (2015)"