### PR TITLE
Add two Erlang papers covering core VM subjects

### DIFF
--- a/languages/erlang/README.md
+++ b/languages/erlang/README.md
@@ -4,3 +4,7 @@
 PhD thesis of Joe Armstrong, Erlang’s co-inventor, describing the origins of Erlang.
 
 * [A History of Erlang](http://webcem01.cem.itesm.mx:8005/erlang/cd/downloads/hopl_erlang.pdf) by Joe Armstrong
+
+* [Characterizing the Scalability of Erlang VM on Many-core Processors](http://www.diva-portal.org/smash/get/diva2:392243/FULLTEXT01.pdfOn) by Jianrong Zhang
+
+* [On the Scalability of the Erlang Term Storage](http://winsh.me/papers/erlang_workshop_2013.pdf) by David Klaftenegger, Konstantinos Sagonas, Kjell Winblad


### PR DESCRIPTION
## Characterizing the Scalability of Erlang VM on Many-core Processors:
### Paper Year: 2011
### Reasons for including paper
Very detailed explanations on various core Erlang VM subjects.

## On the Scalability of the Erlang Term Storage
### Paper Year: 2011
### Reasons for including paper
Detailed writeup on the ETS term storage in the Erlang VM
