### PR TITLE
Add paper on key reinstallation attacks

### DIFF
--- a/cryptography/README.md
+++ b/cryptography/README.md
@@ -7,6 +7,7 @@
 * [RSA Key Extraction via Low-Bandwidth Acoustic Cryptanalysis (2013)](http://www.cs.tau.ac.il/~tromer/papers/acoustic-20131218.pdf)
 * [The Moral Character of Cryptographic Work (2015)](http://web.cs.ucdavis.edu/~rogaway/papers/moral-fn.pdf)
 * [:scroll:](ntru-prime.pdf) [NTRU Prime (2016)](https://eprint.iacr.org/2016/461.pdf) (Daniel J. Bernstein, Chitchanok Chuengsatiansup, Tanja Lange, and Christine van Vredendaal)
+* [Key Reinstallation Attacks: Forcing Nonce Reuse in WPA2 (2017)](https://papers.mathyvanhoef.com/ccs2017.pdf) (Mathy Vanhoef, Frank Piessens)
 
 ## Related Works
 ### [A Mathematical Theory of Cryptography (1945)](http://www.cs.bell-labs.com/who/dmr/pdfs/shannoncryptshrt.pdf) - Shannon


### PR DESCRIPTION
## Paper Title:
Key Reinstallation Attacks: Forcing Nonce Reuse in WPA2
### Paper Year:
2017
### Reasons for including paper
- First "clean" attack on the WPA2 4-way-handshakes
- Breaks Wi-Fi security on many modern devices (including Android 6.0)
- Shows security flaws in the upcoming 802.11ad (WiGig) standard using GCMP
