### PR TITLE
Adding `B4: experience with a globally-deployed software defined WAN`

### DIFF
--- a/networks/README.md
+++ b/networks/README.md
@@ -4,3 +4,4 @@
 * [End-to-End Arguments in System Design](http://www.reed.com/dpr/locus/Papers/EndtoEnd.html)
 * [Can SPDY Really Make the Web Faster?](http://www.comp.lancs.ac.uk/~elkhatib//Docs/2014.06_Netw.pdf)
 * [Datacenter Traffic Control: Understanding Techniques and Trade-offs](https://osf.io/6qzxc/)
+* [B4: Experience with a Globally-Deployed Software Defined WAN](https://dl.acm.org/citation.cfm?id=2486019)


### PR DESCRIPTION
… to networks

## Paper Title:
B4: Experience with a Globally-Deployed Software Defined WAN

### Paper Year:
2013

### Reasons for including paper
- This paper was likely the first large demonstration of SDN networks in industry. 
- In my opinion, it set the benchmark for a number SDN companies on what their product had to be.  
- This is a great demonstration of 'Intent Based Networking' which is something that only now the industry is starting to see
