### PR TITLE
add unikernels

### DIFF
--- a/unikernels/README.md
+++ b/unikernels/README.md
@@ -1,0 +1,10 @@
+## Unikernels (LibOS)
+
+* [Unikernels: Library Operating Systems for the Cloud](https://dl.acm.org/citation.cfm?id=2451167)
+* [IncludeOS: A minimal, resource efficient unikernel for cloud services](https://ieeexplore.ieee.org/document/7396164/)
+* [The rump kernel: A tool for driver development and a toolkit for
+applications](https://www.netbsd.org/gallery/presentations/justin/2015_AsiaBSDCon/justincormack-abc2015.pdf)
+
+### High Availability Through Unikernel
+* [Tardigrade: Leveraging Lightweight Virtual Machines to Easily and Efficiently Construct Fault-Tolerant Services](https://www.usenix.org/node/189029)
+

--- a/unikernels/README.md
+++ b/unikernels/README.md
@@ -1,7 +1,7 @@
 ## Unikernels (LibOS)
 
-* [Unikernels: Library Operating Systems for the Cloud](https://dl.acm.org/citation.cfm?id=2451167)
-* [IncludeOS: A minimal, resource efficient unikernel for cloud services](https://ieeexplore.ieee.org/document/7396164/)
+* [Unikernels: Library Operating Systems for the Cloud](http://anil.recoil.org/papers/2013-asplos-mirage.pdf)
+* [IncludeOS: A minimal, resource efficient unikernel for cloud services](http://folk.uio.no/paalee/publications/2015-cloudcom.pdf)
 * [The rump kernel: A tool for driver development and a toolkit for
 applications](https://www.netbsd.org/gallery/presentations/justin/2015_AsiaBSDCon/justincormack-abc2015.pdf)
 

--- a/unikernels/README.md
+++ b/unikernels/README.md
@@ -2,8 +2,7 @@
 
 * [Unikernels: Library Operating Systems for the Cloud](http://anil.recoil.org/papers/2013-asplos-mirage.pdf)
 * [IncludeOS: A minimal, resource efficient unikernel for cloud services](http://folk.uio.no/paalee/publications/2015-cloudcom.pdf)
-* [The rump kernel: A tool for driver development and a toolkit for
-applications](https://www.netbsd.org/gallery/presentations/justin/2015_AsiaBSDCon/justincormack-abc2015.pdf)
+* [The rump kernel: A tool for driver development and a toolkit for applications](https://www.netbsd.org/gallery/presentations/justin/2015_AsiaBSDCon/justincormack-abc2015.pdf)
 
 ### High Availability Through Unikernel
 * [Tardigrade: Leveraging Lightweight Virtual Machines to Easily and Efficiently Construct Fault-Tolerant Services](https://www.usenix.org/node/189029)


### PR DESCRIPTION
Fixes #520

## Paper Title:
Unikernels: Library Operating Systems for the Cloud

### Paper Year:
2013

### Reasons for including paper
This is the paper that applies libOS on a Cloud setting and rename the approach as Unikernel.

## Paper Title:
IncludeOS: A minimal, resource efficient unikernel for cloud services

### Paper Year:
2015

### Reasons for including paper
IncludeOS is a Unikernel programmed in C++. The source code of IncludeOS is concise and robust. And the project itself is user-friendly in terms of API defining, examples and learning curve.

## Paper Title:
The rump kernel: A tool for driver development and a toolkit for applications

### Paper Year:
2015

### Reasons for including paper
rump kernel established a good ecosystem. Numerous projects, such as nginx, memcached have been made to Unikernel based on rump kernel.

## Paper Title:
Tardigrade: Leveraging Lightweight Virtual Machines to Easily and Efficiently Construct Fault-Tolerant Services

### Paper Year:
2015

### Reasons for including paper
Tardigrade is an early work that achieves HA services using Unikernel. Because of its small memory footprint and short bootstrap time, Unikernel is more preferred than traditional VM for the purpose of replication based HA. 

-
-
-
