### PR TITLE
fix for URL to Flattening Combinators PDF

### DIFF
--- a/combinatory_logic/README.md
+++ b/combinatory_logic/README.md
@@ -1,12 +1,14 @@
 # Combinatory Logic
 
 * [Flattening Combinators: Surviving Without Parentheses]
-  by Chris Okasaki (2003)
+  by Chris Okasaki (2003) ([DOI])
 
 * [Combinatorial Analysis and Computers]
   by Marshall Hall Jr. and Donald E. Knuth (1965)
 
 [Flattening Combinators: Surviving Without Parentheses]:
-    http://www.westpoint.edu/eecs/SiteAssets/SitePages/Faculty%20Publication%20Documents/Okasaki/jfp03flat.pdf
+    https://web.archive.org/web/20170828181221/http://www.westpoint.edu:80/eecs/SiteAssets/SitePages/Faculty%20Publication%20Documents/Okasaki/jfp03flat.pdf
+[DOI]:
+    https://doi.org/10.1017/S0956796802004483
 [Combinatorial Analysis and Computers]:
     http://poncelet.math.nthu.edu.tw/disk5/js/computer/hall-knuth.pdf


### PR DESCRIPTION
This solves https://github.com/papers-we-love/papers-we-love/issues/547

## Paper Title:
Flattening Combinators: Surviving Without Parentheses by Chris Okasaki

### Paper Year:
2003

### Reasons for including paper
updated to a working URL for the PDF.  Added DOI.