### PR TITLE
Fixed URL of Speech Recognition paper

### DIFF
--- a/speech_recognition/README.md
+++ b/speech_recognition/README.md
@@ -2,7 +2,7 @@
 
 ## External Papers
 
-[A tutorial on hidden Markov models and selected applications in speech recognition](http://luthuli.cs.uiuc.edu/~daf/courses/Signals%20AI/Papers/HMMs/0.pdf)
+[A tutorial on hidden Markov models and selected applications in speech recognition](http://www.cs.cmu.edu/~cga/behavior/rabiner1.pdf)
 
 [Weighted Finite-State Transducers in Speech Recognition](http://www.cs.nyu.edu/~mohri/pub/csl01.pdf)
 


### PR DESCRIPTION
## Paper Title:
A Tutorial on Hidden Markov Models and Selected Applications in Speech Recognition

Nothing added, one link fixed