### PR TITLE
Fix broken links after renamed plt to languages-theory

### DIFF
--- a/languages-theory/README.md
+++ b/languages-theory/README.md
@@ -2,26 +2,27 @@
 
 * [Can Programming Be Liberated from the von Neumann Style? A Functional Style and Its Algebra of Programs](http://www.thocp.net/biographies/papers/backus_turingaward_lecture.pdf)
 
-* [:scroll:](https://github.com/papers-we-love/papers-we-love/blob/master/plt/programming-with-algebraic-effects-and-handlers.pdf) [Programming and Reasoning with Algebraic Effects and Dependent Types](http://eb.host.cs.st-andrews.ac.uk/drafts/effects.pdf)
+* [:scroll:](https://github.com/papers-we-love/papers-we-love/blob/master/languages-theory/programming-with-algebraic-effects-and-handlers.pdf) [Programming and Reasoning with Algebraic Effects and Dependent Types](http://eb.host.cs.st-andrews.ac.uk/drafts/effects.pdf)
 
 * [Programming Languages: History and Future](http://www.csee.umbc.edu/courses/undergraduate/CMSC331/resources/papers/sammet1972.pdf)
 
 * [Soft Typing](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.24.9333&rep=rep1&type=pdf)
 
-* [:scroll:](https://github.com/papers-we-love/papers-we-love/blob/master/plt/composable-and-compilable-macros-you-want-it-when.pdf) [Composable and Compilable Macros: You Want it When?](https://www.cs.utah.edu/plt/publications/macromod.pdf)
+* [:scroll:](https://github.com/papers-we-love/papers-we-love/blob/master/languages-theory/composable-and-compilable-macros-you-want-it-when.pdf) [Composable and Compilable Macros: You Want it When?](https://www.cs.utah.edu/plt/publications/macromod.pdf)
 
 * :scroll: [Propositions as Types](http://homepages.inf.ed.ac.uk/wadler/papers/propositions-as-types/propositions-as-types.pdf)
 
-* :scroll: [Fundamental Concepts in Programming Languages](https://github.com/papers-we-love/papers-we-love/blob/master/plt/fundamental-concepts-in-programming-languages.pdf)
+* :scroll: [Fundamental Concepts in Programming Languages](https://github.com/papers-we-love/papers-we-love/blob/master/languages-theory/fundamental-concepts-in-programming-languages.pdf)
 
-* :scroll: [On Understanding Types,Data Abstraction, and Polymorphism](https://github.com/papers-we-love/papers-we-love/blob/master/plt/on-understanding-types-data-abstraction-polymorphism.pdf)
+* :scroll: [On Understanding Types,
+Data Abstraction, and Polymorphism](https://github.com/papers-we-love/papers-we-love/blob/master/languages-theory/on-understanding-types-data-abstraction-polymorphism.pdf)
 
-* :scroll: [Predicate Dispatching](https://github.com/papers-we-love/papers-we-love/blob/master/plt/predicate-dispatching.pdf)
+* :scroll: [Predicate Dispatching](https://github.com/papers-we-love/papers-we-love/blob/master/languages-theory/predicate-dispatching.pdf)
 
-* :scroll: [Principal type-schemes for functional programs](https://github.com/papers-we-love/papers-we-love/blob/master/plt/principal-type-schemes-for-functional-programs.pdf)
+* :scroll: [Principal type-schemes for functional programs](https://github.com/papers-we-love/papers-we-love/blob/master/languages-theory/principal-type-schemes-for-functional-programs.pdf)
 
-* :scroll: [Programming Languages: Application and Interpretation](https://github.com/papers-we-love/papers-we-love/blob/master/plt/programming-languages-application-and-interpretation.pdf)
+* :scroll: [Programming Languages: Application and Interpretation](https://github.com/papers-we-love/papers-we-love/blob/master/languages-theory/programming-languages-application-and-interpretation.pdf)
 
-* :scroll: [The Derivative of a Regular Type is its Type of One-Hole Contexts](https://github.com/papers-we-love/papers-we-love/blob/master/plt/the-derivative-of-a-regular-type-one-hole-contexts.pdf)
+* :scroll: [The Derivative of a Regular Type is its Type of One-Hole Contexts](https://github.com/papers-we-love/papers-we-love/blob/master/languages-theory/the-derivative-of-a-regular-type-one-hole-contexts.pdf)
 
-* :scroll: [Theory in Programming Practice](https://github.com/papers-we-love/papers-we-love/blob/master/plt/theory-in-programming-practice.pdf)
+* :scroll: [Theory in Programming Practice](https://github.com/papers-we-love/papers-we-love/blob/master/languages-theory/theory-in-programming-practice.pdf)


### PR DESCRIPTION
These papers moved under languages-theory in https://github.com/papers-we-love/papers-we-love/pull/561. This Pull Request fixes these broken links ✨ 

<kbd>[Preview fixed README](https://github.com/JuanitoFatas/papers-we-love/blob/634446297c9bad7b70c712d1e3bc99475355a0b0/languages-theory/README.md)</kbd>