### PR TITLE
Differetial privacy and de-anonymization papers

### DIFF
--- a/privacy/README.md
+++ b/privacy/README.md
@@ -1,3 +1,6 @@
 ## Privacy
 
-* [k-ANONYMITY: A MODEL FOR PROTECTING PRIVACY (1998)](https://dataprivacylab.org/dataprivacy/projects/kanonymity/kanonymity.pdf)
+* [k-ANONYMITY: A model for Protecting Privacy (1998)](https://dataprivacylab.org/dataprivacy/projects/kanonymity/kanonymity.pdf)
+* [Differential Privacy(2006)](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/dwork.pdf)
+* [Robust De-anonymization of Large Sparse Datasets(2008)](https://www.cs.utexas.edu/~shmat/shmat_oak08netflix.pdf)
+* [Broken Promises of Privacy: Responding to the Surprising Failure of Anonymization(2010)](https://www.uclalawreview.org/broken-promises-of-privacy-responding-to-the-surprising-failure-of-anonymization-2/)


### PR DESCRIPTION
## Paper Title: Differential Privacy
### Paper Year: 2006
### Reasons for including paper
- Differential Privacy is system of sharing information about dataset while withholding info about individuals
- It's one of the main technical to guarantee the privacy if datasets.
- This technical gained lots of acceptance in consumer application like iOS and Max OSX devices.

## Paper Title: Robust De-anonymization of Large Sparse Datasets
### Paper Year: 2008
- This papers shows how several anonymized info is enough to identify individuals

## Paper Title: Broken Promises of Privacy: Responding to the Surprising Failure of Anonymization
### Paper Year: 2010
- This paper cover legal angle of privacy, anonymization and de-anonymization.

