### PR TITLE
Papers on Web Privacy

### DIFF
--- a/privacy/README.md
+++ b/privacy/README.md
@@ -4,3 +4,5 @@
 * [Differential Privacy(2006)](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/dwork.pdf)
 * [Robust De-anonymization of Large Sparse Datasets(2008)](https://www.cs.utexas.edu/~shmat/shmat_oak08netflix.pdf)
 * [Broken Promises of Privacy: Responding to the Surprising Failure of Anonymization(2010)](https://www.uclalawreview.org/broken-promises-of-privacy-responding-to-the-surprising-failure-of-anonymization-2/)
+* [Timing Attacks on Web Privacy(2000)](https://sip.cs.princeton.edu/pub/webtiming.pdf)
+* [Protecting Browser State from Web Privacy Attacks(2006)](https://crypto.stanford.edu/sameorigin/sameorigin.pdf)


### PR DESCRIPTION
## Paper Title: Timing Attacks on Web Privacy
### Paper Year: 2000
### Reasons for including paper
- Web is most common platform of large scale privacy violation

## Paper Title: Protecting Browser State from Web Privacy Attacks
### Paper Year: 2006
### Reasons for including paper
- Paper cover protecting from privacy on web and compliments above paper well
