### PR TITLE
KHyperLogLog paper: measure of reidentifiability in anonymyzed data

### DIFF
--- a/privacy/README.md
+++ b/privacy/README.md
@@ -6,3 +6,5 @@
 * [Broken Promises of Privacy: Responding to the Surprising Failure of Anonymization(2010)](https://www.uclalawreview.org/broken-promises-of-privacy-responding-to-the-surprising-failure-of-anonymization-2/)
 * [Timing Attacks on Web Privacy(2000)](https://sip.cs.princeton.edu/pub/webtiming.pdf)
 * [Protecting Browser State from Web Privacy Attacks(2006)](https://crypto.stanford.edu/sameorigin/sameorigin.pdf)
+* [KHyperLogLog: Estimating Reidentifiability and
+Joinability of Large Data at Scale(2019)](https://storage.googleapis.com/pub-tools-public-publication-data/pdf/40bc2804cbd3e41ed28dc8991316361eca48630c.pdf)


### PR DESCRIPTION
## Paper Title: KHyperLogLog: Estimating Reidentifiability and Joinability of Large Data at Scale

### Paper Year: 2019

### Reasons for including paper

- Anonymized data still carries risk of leaking user information
- At large org multiple sets of anonymized data can be released and it may unintentionally release private data
- This paper provides estimate of that possibility
