### PR TITLE
fix(readme): change bell system technical journal link

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ We're looking for pull requests related to papers we should add, better organiza
 ### Other Good Places to Find Papers
 
 * [2 Minute Papers](https://www.youtube.com/user/keeroyz)
-* [Bell System Technical Journal, 1922-1983](https://www.alcatel-lucent.com/bell-labs-journals)
+* [Bell System Technical Journal, 1922-1983](https://www.bell-labs.com/our-research/technical-journal/)
 * [Best Paper Awards in Computer Science](http://jeffhuang.com/best_paper_awards.html)
 * [Facebook](https://research.fb.com/publications/)
 * [Google Scholar](http://scholar.google.com/citations?view_op=top_venues&hl=en&vq=eng) (choose a subcategory)


### PR DESCRIPTION
The origin has been redirected to https://www.nokia.com/networks/portfolio/
