### PR TITLE
Update link for Cuckoo Hashing

### DIFF
--- a/data_structures/README.md
+++ b/data_structures/README.md
@@ -3,7 +3,7 @@
 * [Dynamic Hash Tables](http://www.csd.uoc.gr/~hy460/pdf/Dynamic%20Hash%20Tables.pdf)
 * [Simple, Fast, and Practical Non-Blocking and Blocking Concurrent Queue Algorithms](https://www.cs.rochester.edu/u/scott/papers/1996_PODC_queues.pdf)
 * [RRB-Trees: Efﬁcient Immutable Vectors](http://infoscience.epfl.ch/record/169879/files/RMTrees.pdf)
-* [Cuckoo Hashing](http://www.it-c.dk/people/pagh/papers/cuckoo-jour.pdf)
+* [Cuckoo Hashing](https://www.cs.tau.ac.il/~shanir/advanced-seminar-data-structures-2009/bib/pagh01cuckoo.pdf)
 * [Fenwick Tree](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.14.8917&rep=rep1&type=pdf)
 * [Hopscotch Hashing](http://mcg.cs.tau.ac.il/papers/disc2008-hopscotch.pdf)
 


### PR DESCRIPTION
This change updates the link for Data Structures > Cuckoo Hashing. The old link no longer works.