### PR TITLE
Adding Nash 1950, Grief 1993 in econ

### DIFF
--- a/economics/README.md
+++ b/economics/README.md
@@ -4,10 +4,18 @@
 
 * [Auctions and bidding: A guide for computer scientists (2011)](http://www.sci.brooklyn.cuny.edu/~parsons/projects/mech-design/publications/bluffers-final.pdf) by S. Parsons, J. Rodriguez-Aguilar, M. Klein
 
-* [Optimal Bidding in Online Auctions (2001)](http://www.mit.edu/~dbertsim/papers/Revenue%20Management/Optimal%20Bidding%20in%20Online%20Auctions.pdf) by Dimitris Bertsimas, Jerey Hawkinsy, Georgia Perakis 
+* [Optimal Bidding in Online Auctions (2001)](http://www.mit.edu/~dbertsim/papers/Revenue%20Management/Optimal%20Bidding%20in%20Online%20Auctions.pdf) by Dimitris Bertsimas, Jerey Hawkinsy, Georgia Perakis
 
 * [Online Ad Auctions (2009)](online-ad-auctions.pdf) by Hal Varian
 
 ## Open Source
 
 * [The Simple Economics of Open Source  (2000)](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=224008) by Josh Lerner and Jean Tirole
+
+## Contract enforcement/principal-agent models
+
+* [Contract Enforceability and Economic Institutions in Early Trade: The Maghribi Traders' Coalition (1993)](https://web.stanford.edu/~avner/Greif_Papers/1993%20Greif%20AER%201993.pdf) by Avner Grief
+
+## Game theory
+
+* [Two-person cooperative games (1950)](https://www.rand.org/content/dam/rand/pubs/papers/2005/P172.pdf) by John Forbes Nash


### PR DESCRIPTION
## Paper Title: Contract Enforceability and Economic Institutions in Early Trade: The Maghribi Traders' Coalition

### Paper Year: 1993

### Reasons for including paper

This is a fun and one of the most important papers exploring the principal-agent model in economics. It relates to contract enforceability (moral hazard, etc).

<hr>

## Paper Title: Two-person cooperative games

### Paper Year: 1950

### Reasons for including paper

This is the paper that basically kickstarted game theory - and all its applications in economics, bio, etc. There are Python packages which computationally solve for Nash equilibria: e.g. [NashPy](https://nashpy.readthedocs.io/en/latest/)