### PR TITLE
Update link for f4 paper

### DIFF
--- a/datastores/README.md
+++ b/datastores/README.md
@@ -2,7 +2,7 @@
 
 * [Calvin: Fast Distributed Transactions for Partitioned Database Systems](http://cs.yale.edu/homes/thomson/publications/calvin-sigmod12.pdf)
 
-* [f4: Facebook’s Warm BLOB Storage System](http://www-bcf.usc.edu/~wyattllo/papers/f4-osdi14.pdf)
+* [f4: Facebook’s Warm BLOB Storage System](https://www.usenix.org/system/files/conference/osdi14/osdi14-paper-muralidhar.pdf)
 
 * [The Case for Determinism in Database Systems](http://cs-www.cs.yale.edu/homes/dna/papers/determinism-vldb10.pdf)
 


### PR DESCRIPTION
The previous link is 404ing now
