### PR TITLE
Fix no longer active link to John Backus’ Turning Award paper

### DIFF
--- a/languages-theory/README.md
+++ b/languages-theory/README.md
@@ -1,6 +1,6 @@
 # Programming Language Theory
 
-* [Can Programming Be Liberated from the von Neumann Style? A Functional Style and Its Algebra of Programs](http://www.thocp.net/biographies/papers/backus_turingaward_lecture.pdf)
+* [Can Programming Be Liberated from the von Neumann Style? A Functional Style and Its Algebra of Programs](https://dl.acm.org/doi/pdf/10.1145/359576.359579)
 
 * [:scroll:](https://github.com/papers-we-love/papers-we-love/blob/master/languages-theory/programming-with-algebraic-effects-and-handlers.pdf) [Programming and Reasoning with Algebraic Effects and Dependent Types](http://eb.host.cs.st-andrews.ac.uk/drafts/effects.pdf)
 


### PR DESCRIPTION
Fix no longer active link to John Backus’ Turning Award "Can programming be liberated from the von Neumann style? a functional style and its algebra of programs"

