### PR TITLE
Add On-the-Fly Garbage Collection Paper

### DIFF
--- a/garbage_collection/README.md
+++ b/garbage_collection/README.md
@@ -5,6 +5,7 @@
 * [Incremental Collection of Mature Objects](http://pdf.aminer.org/000/465/194/incremental_collection_of_mature_objects.pdf)
 * [:scroll:](incremental_mature_garbage_collection_using_the_train_algorithm.pdf) [Incremental Mature Garbage Collection Using the Train Algorithm](https://www.sics.se/~seif/DatalogiII/Book/train.ps)
 * [Incremental Garbage Collection: The Train Algorithm](http://www.ssw.uni-linz.ac.at/General/Staff/TW/Wuerthinger05Train.pdf)
+* [On-the-Fly Garbage Collection: An Exercise in Cooperation](https://lamport.azurewebsites.net/pubs/garbage.pdf)
 * [:scroll:](the_lisp_ii_garbage_collector.pdf) [The Lisp II Garbage Collector](ftp://publications.ai.mit.edu/ai-publications/pdf/AIM-019.pdf)
 * [The Treadmill: Real-Time Garbage Collection Without Motion Sickness](http://home.pipeline.com/~hbaker1/NoMotionGC.html)
 * [Parallel Generational-Copying Garbage Collection with a Block-Structured


### PR DESCRIPTION
## Paper Title: On-the-Fly Garbage Collection: An Exercise in Cooperation

### Paper Year: 1978

### Reasons for including paper

As indicated in [this blogpost](https://fgiesen.wordpress.com/2017/12/21/papers-i-like-part-7/):

> This is the paper that introduced concurrent Garbage Collection via the tri-color marking invariant. It forms the basis for most non-concurrent incremental collectors as well. No matter where you stand on garbage collection, I think it’s useful (and interesting!) to know how collectors work, and this is one paper you’ll be hard-pressed to avoid when delving into the matter; despite the claim in the paper’s introduction that “it has hardly been our purpose to contribute specifically to the art of garbage collection, and consequently no practical significance is claimed for our solution”, this is definitely one of the most important and influential papers on GC ever written.
