### PR TITLE
Use relative paths in scripts/download.sh

### DIFF
--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -11,7 +11,7 @@ download_for_directory() {
 
     for f in *; do
         if [[ -d ${f} ]]; then
-            download_for_directory ${f} &
+            download_for_directory "./${f}" &
         fi
     done
 


### PR DESCRIPTION
If there is another folder with the same name in your path when running the script, it will enter that folder and recursively try to download all the files. It the folder is big enough, it can hang the computer. Using relative paths fixes the problem.
