### PR TITLE
let lychee handle advanced globbing

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -17,7 +17,7 @@ jobs:
       #env:
       #  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       with:
-        args: '--verbose --max-retries 4 --no-progress **/*.md'
+        args: '--verbose --max-retries 4 --no-progress "**/*.md"'
 
     - name: Create Issue From File
       uses: peter-evans/create-issue-from-file@v2


### PR DESCRIPTION
The workflow does not quote `**/*.md`, so bash will handle the globbing, which does not support the recursive pattern `**`. 

After quoting, bash will pass `**/*.md` to lychee, which will find all markdown files in the repository.