### PR TITLE
Correct links instead of commenting them out (override of #740)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,7 +8,7 @@ Papers We Love events are for anyone interested in Computer Science/Computer Eng
 
 **Be an adult, don't be a jerk.**
 
-We value the participation of each member of the community and want all attendees to have an enjoyable and fulfilling experience. Accordingly, all attendees are expected to show respect and courtesy to other attendees throughout the meet-ups and at all Papers We Love events and interactions on the GitHub repository, IRC, [gitter](https://gitter.im/papers-we-love/), or [Slack](https://paperswelove.slack.com/messages/general/) channels.
+We value the participation of each member of the community and want all attendees to have an enjoyable and fulfilling experience. Accordingly, all attendees are expected to show respect and courtesy to other attendees throughout the meet-ups and at all Papers We Love events and interactions on the GitHub repository, or [Discord](https://discord.gg/XnarqB59r2).
 
 Need help?
 ----------

--- a/cryptography/README.md
+++ b/cryptography/README.md
@@ -1,6 +1,6 @@
 # Cryptography 
 
-* [A Method for Obtaining Digital Signatures and Public-Key Cryptosystems (1977)](http://people.csail.mit.edu/rivest/Rsapaper.pdf)
+* [A Method for Obtaining Digital Signatures and Public-Key Cryptosystems (1977)](https://dl.acm.org/doi/10.1145/359340.359342)
 * [Twenty Years of Attacks on the RSA Cryptosystem (1999)](https://crypto.stanford.edu/~dabo/papers/RSA-survey.pdf)
 * :scroll: [Communication Theory of Secrecy Systems (1949)](communication-theory-of-secrecy-systems.pdf)
 * [New Directions in Cryptography (1976)](http://www-ee.stanford.edu/~hellman/publications/24.pdf)

--- a/design/README.md
+++ b/design/README.md
@@ -1,5 +1,5 @@
 # Design
-* [No Silver Bullet — Essence and Accidents of Software Engineering](http://www.cs.unc.edu/techreports/86-020.pdf)
+* [No Silver Bullet — Essence and Accidents of Software Engineering](https://www.semanticscholar.org/paper/No-Silver-Bullet-Essence-and-Accidents-of-Software-Brooks/ed0759b7001f8be53bb4282750e98198b359307d)
 * [Traits: A Mechanism for Fine-Grained Reuse](http://scg.unibe.ch/archive/papers/Duca06bTOPLASTraits.pdf)
 * [THING-MODEL-VIEW-EDITOR an Example from a planningsystem](http://heim.ifi.uio.no/~trygver/1979/mvc-1/1979-05-MVC.pdf)
 

--- a/languages-paradigms/functional_reactive_programming/README.md
+++ b/languages-paradigms/functional_reactive_programming/README.md
@@ -2,7 +2,7 @@
 
 * [Functional Reactive Programming, Continued](https://www.antonycourtney.com/pubs/frpcont.pdf)
 
-* [Event-Driven FRP](http://www.cs.yale.edu/homes/zwan/papers/mcu/efrp.pdf)
+* [Event-Driven FRP](https://www.researchgate.net/publication/2415013_Event-driven_FRP)
 
 * [Real-Time FRP](https://csiflabs.cs.ucdavis.edu/~johari/refs/rt-frp.pdf)
 

--- a/testing/tdd/README.md
+++ b/testing/tdd/README.md
@@ -5,4 +5,4 @@
 
 ## In industrial teams
 
-[Realizing quality improvement through test driven development: results and experiences of four industrial teams](https://github.com/tpn/pdfs/raw/master/Realizing%20Quality%20Improvement%20Through%20Test%20Driven%20Development%20-%20Results%20and%20Experiences%20of%20Four%20Industrial%20Teams%20(nagappan_tdd).pdf). This paper is important because it one of the few instances of quantitative research about TDD in industrial teams (not in controlled environments)
+[Realizing quality improvement through test driven development: results and experiences of four industrial teams](https://www.microsoft.com/en-us/research/wp-content/uploads/2009/10/Realizing-Quality-Improvement-Through-Test-Driven-Development-Results-and-Experiences-of-Four-Industrial-Teams-nagappan_tdd.pdf). This paper is important because it one of the few instances of quantitative research about TDD in industrial teams (not in controlled environments)


### PR DESCRIPTION
#740 comments out some links and text. This PR updates the incorrect links with new ones.