### PR TITLE
chore: Update outdated GitHub Actions version

### DIFF
--- a/.github/workflows/lychee.yml
+++ b/.github/workflows/lychee.yml
@@ -10,7 +10,7 @@ jobs:
   links:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.3.4
+    - uses: actions/checkout@v6
 
     - name: Link Checker
       uses: lycheeverse/lychee-action@master


### PR DESCRIPTION
### Note

This PR does not relate to a paper.

---

- Updating to a newer version of the GitHub Action to ensure compatibility and benefits.
- Ensuring the workflow uses the latest features and security patches.
- Maintaining alignment with best practices and current standards.