### PR TITLE
fix: update unreachable link in api_design/README.md

### DIFF
--- a/api_design/README.md
+++ b/api_design/README.md
@@ -1,5 +1,5 @@
 # API Design
 
-* [Architectural Styles and the Design of Network-based Software Architectures (REST) by Roy Fielding](https://www.ics.uci.edu/~fielding/pubs/dissertation/fielding_dissertation.pdf)
+* [Architectural Styles and the Design of Network-based Software Architectures (REST) by Roy Fielding](https://roy.gbiv.com/pubs/dissertation/fielding_dissertation.pdf)
 
 * :scroll: [Little Manual of API Design](api-design.pdf)


### PR DESCRIPTION
**Reason for change:**
The original UC Irvine link for Roy Fielding's dissertation ("Architectural Styles and the Design of Network-based Software Architectures (REST)") is no longer reachable. 

**What was done:**
Updated the URL to the official, active link hosted directly on Roy Fielding's personal website (`roy.gbiv.com`).