### PR TITLE
Update README with additional AI research papers missing from the collection

### DIFF
--- a/artificial_intelligence/README.md
+++ b/artificial_intelligence/README.md
@@ -15,3 +15,23 @@
     > This paper proposes a method for translating music across musical instruments, genres, and styles. It is based on a multi-domain wavenet autoencoder, with a shared encoder and a disentangled latent space that is trained end-to-end on waveforms. Employing a diverse training dataset and large net capacity, the domain-independent encoder enables translation even from musical domains that were not seen during training. The method is unsupervised and does not rely on supervision in the form of matched samples between domains or musical transcriptions. This method is evaluated on NSynth, as well as on a dataset collected from professional musicians, and achieve convincing translations, even when translating from whistling, potentially enabling the creation of instrumental music by untrained humans.
 
 * [Attention is all you need](http://papers.neurips.cc/paper/7181-attention-is-all-you-need.pdf) by Ashish Vaswani et al.
+
+* [https://jair.org/index.php/jair/article/view/10302] byChawla, Bowyer, Hall & Kegelmeyer — JAIR Vol. 16, 2002
+SMOTE: Synthetic Minority Over-sampling Technique 
+SMOTE addresses the imbalanced learning problem by generating synthetic minority class instances through an iterative process — selecting minority instances and synthesizing new ones via interpolation — which became the dominant strategy in class-imbalance research worldwide.
+
+* [https://jair.org/index.php/jair/article/view/10166] by Kaelbling, Littman & Moore
+    > Reinforcement Learning: A Survey
+This paper surveys the field of reinforcement learning from a computer-science perspective, covering central issues including exploration vs. exploitation, Markov decision theory, learning from delayed reinforcement, generalization, hierarchy, and hidden state — concluding with implemented systems and an assessment of practical utility. With 6,000+ citations, it remains the canonical early survey of RL.
+
+* [https://jair.org/index.php/jair/article/view/10127] by Dietterich & Bakiri
+    > Solving Multiclass Learning Problems via Error-Correcting Output Codes
+This paper compares direct multiclass approaches to a new technique in which error-correcting codes are employed as a distributed output representation — demonstrating that these output representations improve the generalization performance of both C4.5 and backpropagation across a wide range of multiclass learning tasks, and that the approach is robust with respect to training sample size, code assignments, and overfitting avoidance.
+
+* [ https://jair.org/index.php/jair/article/view/10297] by Philip Resnik
+   > Semantic Similarity in a Taxonomy: An Information-Based Measure
+This paper introduced an information-theoretic measure of semantic similarity using WordNet taxonomies, grounding word similarity in the information content of the lowest common subsumer. It became a cornerstone of NLP, knowledge graphs, and word sense disambiguation research.
+
+* [ https://jair.org/index.php/jair/article/view/10396] by Erkan & Radev
+   >  LexRank: Graph-based Lexical Centrality as Salience in Text Summarization
+LexRank computes sentence importance based on eigenvector centrality in a graph representation of sentences, using an intra-sentence cosine similarity connectivity matrix as the adjacency matrix — and ranked first place in more than one task in the DUC 2004 summarization evaluation. It predated and influenced PageRank-style NLP methods.


### PR DESCRIPTION
Added several influential papers on AI and machine learning, including topics on reinforcement learning, semantic similarity, and text summarization.

## Paper Title: SMOTE: Synthetic Minority Over-sampling Technique
### Paper Year: 2002
### Reasons for including paper
- Addresses the critical real-world problem of class imbalance in supervised learning by generating synthetic minority samples rather than simple duplication
- One of the most cited machine learning papers of all time (20,000+ citations), foundational to any practitioner working with imbalanced datasets
- Freely available via JAIR (open access), not currently referenced anywhere in the repository

---

## Paper Title: Reinforcement Learning: A Survey
### Paper Year: 1996
### Reasons for including paper
- The canonical early survey of reinforcement learning — covers exploration vs. exploitation, Markov decision theory, delayed reward, and hierarchy in a single accessible paper
- 6,000+ citations; shaped the vocabulary and research agenda of the entire RL field
- Freely available via JAIR (open access), not currently referenced anywhere in the repository

---

## Paper Title: Solving Multiclass Learning Problems via Error-Correcting Output Codes
### Paper Year: 1995
### Reasons for including paper
- Introduced the use of error-correcting codes as output representations for multiclass classification, improving generalization across C4.5 and backpropagation
- 5,000+ citations; directly influenced ensemble methods, multi-label learning, and modern classifier design
- Freely available via JAIR (open access), not currently referenced anywhere in the repository

---

## Paper Title: Semantic Similarity in a Taxonomy: An Information-Based Measure and its Application to Problems of Ambiguity in Natural Language
### Paper Year: 1999
### Reasons for including paper
- Introduced an information-theoretic grounding for semantic similarity using WordNet, replacing ad hoc edge-counting with principled probability-based measurement
- 5,000+ citations; cornerstone of NLP, word sense disambiguation, and modern knowledge graph research
- Freely available via JAIR (open access), not currently referenced anywhere in the repository

---

## Paper Title: LexRank: Graph-based Lexical Centrality as Salience in Text Summarization
### Paper Year: 2004
### Reasons for including paper
- Applied eigenvector centrality to sentence graphs for extractive summarization, predating and influencing the widespread use of PageRank-style methods in NLP
- 3,000+ citations; ranked first in multiple tasks at DUC 2004 and remains a benchmark reference in summarization research
- Freely available via JAIR (open access), not currently referenced anywhere in the repository