### PR TITLE
docs: update master links to main

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,14 +5,14 @@ We have a few guidelines in place to keep the repo clean and easy to navigate. W
 ### Follow the group's ethos
 
 We want to help bring academic research closer to practitioners and we strive to:
-* **Adhere to [Papers We Love Code of Conduct](https://github.com/papers-we-love/papers-we-love/blob/master/CODE_OF_CONDUCT.md)**.
+* **Adhere to [Papers We Love Code of Conduct](https://github.com/papers-we-love/papers-we-love/blob/main/CODE_OF_CONDUCT.md)**.
 * **Keep the quality of papers listed high:** Books, blogposts, and/or reference pdfs don't go through the same review process that academic papers do and we won't add them to this repo.
 * **Help people understand why a paper is important:** We ask that you include with your commit an update to the directory README with a short justification of why you love this paper (for example: A paper might be interesting because it spawned a new domain, it was exceptionally well-written, or perhaps it was completely wrong about something.) Take look at this [pull request](https://github.com/papers-we-love/papers-we-love/pull/282/files) as a model.
 
 ### Respect content licenses
 
 * **We will only merge pull requests that contain research papers that allow digital distribution.** Papers whose copyright prohibits redistribution will not be accepted; for example [license 8](http://www.acm.org/publications/policies/copyright-policy-v8/) from the [ACM digital library](http://www.acm.org/publications/policies/copyright_policy).
-* We encourage papers that do not allow digital distribution to be added to a README, with a link to the source URL, in the appropriate subject's folder. For example, [the distributed systems README](https://github.com/papers-we-love/papers-we-love/blob/master/distributed_systems/README.md).
+* We encourage papers that do not allow digital distribution to be added to a README, with a link to the source URL, in the appropriate subject's folder. For example, [the distributed systems README](https://github.com/papers-we-love/papers-we-love/blob/main/distributed_systems/README.md).
 
 ### Follow our commit, naming, and directory-organization conventions
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Papers We Love** (*PWL*) is a community built around reading, discussing and learning more about academic computer science papers. This repository serves as a directory of some of the best papers the community can find, bringing together documents scattered across the web. You can also visit the [Papers We Love site](http://paperswelove.org/) for more info.
 
-Due to [licenses](https://github.com/papers-we-love/papers-we-love/blob/master/.github/CONTRIBUTING.md#respect-content-licenses) we cannot always host the papers themselves (when we do, you will see a :scroll: emoji next to its title in the directory README) but we can provide links to their locations.
+Due to [licenses](https://github.com/papers-we-love/papers-we-love/blob/main/.github/CONTRIBUTING.md#respect-content-licenses) we cannot always host the papers themselves (when we do, you will see a :scroll: emoji next to its title in the directory README) but we can provide links to their locations.
 
 If you enjoy the papers, perhaps stop by a local chapter meetup and join in on the vibrant discussions around them. You can also discuss *PWL* events, the content in this repository, and/or anything related to *PWL* on our [Discord](https://discord.gg/Tu2VynkRWV) server.
 

--- a/caching/README.md
+++ b/caching/README.md
@@ -1,6 +1,6 @@
 # Caching
 
-* [:scroll:](a-constant-algorithm-for-implementing-the-lfu-cache-eviction-scheme.pdf) [An O(1) algorithm for implementing the LFU cache eviction scheme](https://github.com/papers-we-love/papers-we-love/blob/master/caching/a-constant-algorithm-for-implementing-the-lfu-cache-eviction-scheme.pdf) by Prof. Ketan Shah, Anirban Mitra, Dhruv Matani
+* [:scroll:](a-constant-algorithm-for-implementing-the-lfu-cache-eviction-scheme.pdf) [An O(1) algorithm for implementing the LFU cache eviction scheme](https://github.com/papers-we-love/papers-we-love/blob/main/caching/a-constant-algorithm-for-implementing-the-lfu-cache-eviction-scheme.pdf) by Prof. Ketan Shah, Anirban Mitra, Dhruv Matani
 
 * [:scroll:](2q-a-low-overhead-high-performance-buffer-management-replacement-algorithm.pdf) [2Q: A Low Overhead High Performance Buffer Management Replacement Algorithm](http://www.vldb.org/conf/1994/P439.PDF) by Theodore Johnson and Dennis Shasha
 

--- a/languages-theory/README.md
+++ b/languages-theory/README.md
@@ -8,23 +8,23 @@
 
 * [Soft Typing](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.24.9333&rep=rep1&type=pdf)
 
-* [:scroll:](https://github.com/papers-we-love/papers-we-love/blob/master/languages-theory/composable-and-compilable-macros-you-want-it-when.pdf) [Composable and Compilable Macros: You Want it When?](https://www.cs.utah.edu/plt/publications/macromod.pdf)
+* [:scroll:](https://github.com/papers-we-love/papers-we-love/blob/main/languages-theory/composable-and-compilable-macros-you-want-it-when.pdf) [Composable and Compilable Macros: You Want it When?](https://www.cs.utah.edu/plt/publications/macromod.pdf)
 
 * :scroll: [Propositions as Types](http://homepages.inf.ed.ac.uk/wadler/papers/propositions-as-types/propositions-as-types.pdf)
 
 * :scroll: [Liquid Types](https://goto.ucsd.edu/~rjhala/liquid/liquid_types.pdf)
 
-* :scroll: [Fundamental Concepts in Programming Languages](https://github.com/papers-we-love/papers-we-love/blob/master/languages-theory/fundamental-concepts-in-programming-languages.pdf)
+* :scroll: [Fundamental Concepts in Programming Languages](https://github.com/papers-we-love/papers-we-love/blob/main/languages-theory/fundamental-concepts-in-programming-languages.pdf)
 
 * :scroll: [On Understanding Types,
-Data Abstraction, and Polymorphism](https://github.com/papers-we-love/papers-we-love/blob/master/languages-theory/on-understanding-types-data-abstraction-polymorphism.pdf)
+Data Abstraction, and Polymorphism](https://github.com/papers-we-love/papers-we-love/blob/main/languages-theory/on-understanding-types-data-abstraction-polymorphism.pdf)
 
-* :scroll: [Predicate Dispatching](https://github.com/papers-we-love/papers-we-love/blob/master/languages-theory/predicate-dispatching.pdf)
+* :scroll: [Predicate Dispatching](https://github.com/papers-we-love/papers-we-love/blob/main/languages-theory/predicate-dispatching.pdf)
 
-* :scroll: [Principal type-schemes for functional programs](https://github.com/papers-we-love/papers-we-love/blob/master/languages-theory/principal-type-schemes-for-functional-programs.pdf)
+* :scroll: [Principal type-schemes for functional programs](https://github.com/papers-we-love/papers-we-love/blob/main/languages-theory/principal-type-schemes-for-functional-programs.pdf)
 
-* :scroll: [Programming Languages: Application and Interpretation](https://github.com/papers-we-love/papers-we-love/blob/master/languages-theory/programming-languages-application-and-interpretation.pdf)
+* :scroll: [Programming Languages: Application and Interpretation](https://github.com/papers-we-love/papers-we-love/blob/main/languages-theory/programming-languages-application-and-interpretation.pdf)
 
-* :scroll: [The Derivative of a Regular Type is its Type of One-Hole Contexts](https://github.com/papers-we-love/papers-we-love/blob/master/languages-theory/the-derivative-of-a-regular-type-one-hole-contexts.pdf)
+* :scroll: [The Derivative of a Regular Type is its Type of One-Hole Contexts](https://github.com/papers-we-love/papers-we-love/blob/main/languages-theory/the-derivative-of-a-regular-type-one-hole-contexts.pdf)
 
-* :scroll: [Theory in Programming Practice](https://github.com/papers-we-love/papers-we-love/blob/master/languages-theory/theory-in-programming-practice.pdf)
+* :scroll: [Theory in Programming Practice](https://github.com/papers-we-love/papers-we-love/blob/main/languages-theory/theory-in-programming-practice.pdf)

--- a/processes/README.md
+++ b/processes/README.md
@@ -1,4 +1,4 @@
 ## Process Control 
 
-* [:scroll:](https://github.com/papers-we-love/papers-we-love/blob/master/processes/communicating-sequential-processes.pdf) [Communicating Sequential Processes](http://www.cs.ucf.edu/courses/cop4020/sum2009/CSP-hoare.pdf)
+* [:scroll:](https://github.com/papers-we-love/papers-we-love/blob/main/processes/communicating-sequential-processes.pdf) [Communicating Sequential Processes](http://www.cs.ucf.edu/courses/cop4020/sum2009/CSP-hoare.pdf)
 * [Calculus of Communicating Systems](https://moodle.risc.jku.at/pluginfile.php/3407/mod_resource/content/1/A%20Calculus%20of%20Communicating%20Systems%5B1980%5D.pdf)

--- a/sublinear_algorithms/README.md
+++ b/sublinear_algorithms/README.md
@@ -2,13 +2,13 @@
 
 ## Hosted Papers :open_file_folder:
 
-* :scroll: **[Probablistic Counting Algorithms for Database Applications](https://github.com/papers-we-love/papers-we-love/blob/master/sublinear_algorithms/1985-Flajolet-Probabilistic-counting.pdf)**
+* :scroll: **[Probablistic Counting Algorithms for Database Applications](https://github.com/papers-we-love/papers-we-love/blob/main/sublinear_algorithms/1985-Flajolet-Probabilistic-counting.pdf)**
 
     This paper introduces a class of probabilistic counting algorithms with which one can estimate the number of distinct elements in a large collection of data (typically a large file stored on disk) in a single pass using only a small additional storage (typically less than a hundred binary words) and only a few operations per element scanned. The algorithms are based on statistical observations made on bits of hashed values of records. They are by construction totally insensitive to the replicative structure of elements in the file; they can be used in the context of distributed systems without any degradation of performances and prove especially useful in the context of data bases query optimisation
 
     *Flajolet, Philippe, and G. Nigel Martin. "Probabilistic counting algorithms for data base applications." Journal of computer and system sciences 31.2 (1985): 182-209.*
 
-* :scroll: **[An Elementary Proof of a Theorem of Johnson and Lindenstrauss](https://github.com/papers-we-love/papers-we-love/blob/master/sublinear_algorithms/An-Elementary-Proof-of-a-Theorem-of-Johnson-and-Lindenstrauss.pdf)**
+* :scroll: **[An Elementary Proof of a Theorem of Johnson and Lindenstrauss](https://github.com/papers-we-love/papers-we-love/blob/main/sublinear_algorithms/An-Elementary-Proof-of-a-Theorem-of-Johnson-and-Lindenstrauss.pdf)**
 
     A result of Johnson and Lindenstrauss shows that a set of n points in high dimensional Euclidean space can be mapped into an `O(log n/ϵ2)-dimensional` Euclidean space such that the distance between any two points changes by only a factor of `(1 ± ϵ)`. In this note, we prove this theorem using elementary probabilistic techniques.
 

--- a/time_series/README.md
+++ b/time_series/README.md
@@ -6,7 +6,7 @@ one-pass processing.
 
 The included documents are:
 
-* [:scroll:](https://github.com/papers-we-love/papers-we-love/blob/master/time_series/operators-on-inhomogeneous-time-series.pdf) [Operators on Inhomogeneous Time Series](http://papers.ssrn.com/sol3/papers.cfm?abstract_id=208278)  - Gilles O. Zumbach and Ulrich A. Müller
+* [:scroll:](https://github.com/papers-we-love/papers-we-love/blob/main/time_series/operators-on-inhomogeneous-time-series.pdf) [Operators on Inhomogeneous Time Series](http://papers.ssrn.com/sol3/papers.cfm?abstract_id=208278)  - Gilles O. Zumbach and Ulrich A. Müller
 
   We present a toolbox to compute and extract information from
   inhomogeneous (i.e. unequally spaced) time series. The toolbox
@@ -19,7 +19,7 @@ The included documents are:
   basic set of operators, we easily construct more powerful combined
   operators which cover a wide set of typical applications.
 
-* [:scroll:](https://github.com/papers-we-love/papers-we-love/blob/master/time_series/ts-asap.pdf)
+* [:scroll:](https://github.com/papers-we-love/papers-we-love/blob/main/time_series/ts-asap.pdf)
   [ASAP: Automatic Smoothing for Attention Prioritization in Streaming Time Series Visualization](https://arxiv.org/abs/1703.00983)  - Kexin Rong, Peter Bailis
 
   Time Series smoothing method to better prioritize attention in time series


### PR DESCRIPTION
All outdated links have been updated from `master` to `main`.